### PR TITLE
Clarification in boot message

### DIFF
--- a/arm9/source/patches.c
+++ b/arm9/source/patches.c
@@ -632,7 +632,7 @@ u32 patchKernel9Fs(u8 *pos, u32 size)
     "updating system FW).\n"
     "Accept the risk to apply this patch.\n\n"
     "Patch point : 0x%08X\n"
-    "If the value above is 0x00000000 the patch isn't\n"
+    "If the value shown above equals 0x00000000 the patch isn't\n"
     "available for your console, if so let us know!";
 
     if(warn(msg, (uintptr_t)off) && off)


### PR DESCRIPTION
It is the smallest change, but whatever:
Me and I guess [this GBATemp user](https://gbatemp.net/threads/beta-release-tester-wanted-kernel9-patch-to-speed-up-boot-speed-on-high-capacity-sd-card.673415/post-10695524) read the warning as "if value is above 0x0 your console is not compatible" instead of what it is: "if above value is 0x0"   
This should make it a little more clear.   

That said, your patch is in testing so discard this PR without second thought if you want.